### PR TITLE
fix buffer overflow

### DIFF
--- a/vinstall.c
+++ b/vinstall.c
@@ -66,7 +66,7 @@ int main() {
 		system("hdiutil attach iOS.dmg");
 		
 		printf("Enter Disk identifier of */Volumes/iOS* in the form /dev/disk9s2 from the output above: ");
-		scanf("%s", &invapfs2);
+		scanf("%14s", &invapfs2);
 		char * invapfscom = concatenate(invapfs1, &invapfs2, invapfs3);
 		printf("\nWaiting For Connection To Disk...\n");
 		


### PR DESCRIPTION
According to [here](https://stackoverflow.com/questions/1621394/how-to-prevent-scanf-causing-a-buffer-overflow-in-c), if scanf() is used without a max string length in front of the %s conversion character, a buffer overflow can occur.